### PR TITLE
Upgrade hhast to ^3.28.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,6 @@
     "description": "Common interface for HTTP messages",
     "homepage": "https://github.com/facebookexperimental/hack-http-request-response-interfaces",
     "require-dev": {
-        "hhvm/hhast": "^0.6.0|^1.0.0"
+        "hhvm/hhast": "^3.28.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,103 +4,102 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6abd3ba8d08b35fef675f8a4736330e",
+    "content-hash": "3b72c82a88b9b8734158c9a50048659a",
     "packages": [],
     "packages-dev": [
         {
-            "name": "fredemmott/hack-error-suppressor",
-            "version": "v1.0.1",
+            "name": "facebook/hh-clilib",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/fredemmott/hack-error-suppressor.git",
-                "reference": "cb145c771b50f4f4eeec8c9cac4740df3d486a12"
+                "url": "https://github.com/hhvm/hh-clilib.git",
+                "reference": "d8d19b4f230b6f02c6fc2be16ec1fb19c3fcbc0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fredemmott/hack-error-suppressor/zipball/cb145c771b50f4f4eeec8c9cac4740df3d486a12",
-                "reference": "cb145c771b50f4f4eeec8c9cac4740df3d486a12",
-                "shasum": ""
-            },
-            "require-dev": {
-                "91carriage/phpunit-hhi": "^5.6",
-                "phpunit/phpunit": "^5.7"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "ISC"
-            ],
-            "authors": [
-                {
-                    "name": "Fred Emmott",
-                    "email": "fred@fredemmott.co.uk"
-                }
-            ],
-            "description": "Suppress HHVM's automatic conversion of typechecker errors to fatals.",
-            "time": "2017-05-02T03:07:37+00:00"
-        },
-        {
-            "name": "hhvm/hhast",
-            "version": "v1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hhvm/hhast.git",
-                "reference": "97916ba3945d95f89ba6e33ceadbde16bfa0e02e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhast/zipball/97916ba3945d95f89ba6e33ceadbde16bfa0e02e",
-                "reference": "97916ba3945d95f89ba6e33ceadbde16bfa0e02e",
+                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/d8d19b4f230b6f02c6fc2be16ec1fb19c3fcbc0e",
+                "reference": "d8d19b4f230b6f02c6fc2be16ec1fb19c3fcbc0e",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^3.24.0",
-                "hhvm/hsl": "^1.0.0",
+                "hhvm/hsl": "^3.26",
+                "hhvm/type-assert": "^3.2"
+            },
+            "require-dev": {
+                "91carriage/phpunit-hhi": "^5.7",
+                "facebook/fbexpect": "^1.1.0",
+                "hhvm/hhast": "^3.27.0",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "time": "2018-08-27T20:03:09+00:00"
+        },
+        {
+            "name": "hhvm/hhast",
+            "version": "v3.28.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/hhast.git",
+                "reference": "ef96527025803cb41ab13f657651cef3ff5bfb8f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/hhast/zipball/ef96527025803cb41ab13f657651cef3ff5bfb8f",
+                "reference": "ef96527025803cb41ab13f657651cef3ff5bfb8f",
+                "shasum": ""
+            },
+            "require": {
+                "facebook/hh-clilib": "^1.1.1",
+                "hhvm": "^3.28.0",
+                "hhvm/hsl": "^1.0.0|^3.26.0",
                 "hhvm/type-assert": "^3.1"
             },
             "require-dev": {
                 "91carriage/phpunit-hhi": "^5.7",
-                "facebook/fbexpect": "^0.4.0",
-                "facebook/hack-codegen": "~3.0.3",
+                "facebook/fbexpect": "^1.1.0",
+                "facebook/hack-codegen": "~3.2.1",
                 "hhvm/hhvm-autoload": "^1.5",
                 "phpunit/phpunit": "^5.7"
             },
             "bin": [
-                "bin/hhast-lint"
+                "bin/hhast-lint",
+                "bin/hhast-inspect"
             ],
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2018-03-01T22:15:51+00:00"
+            "license": [
+                "MIT"
+            ],
+            "time": "2018-08-29T18:15:15+00:00"
         },
         {
             "name": "hhvm/hhvm-autoload",
-            "version": "v1.6.3",
+            "version": "1.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhvm-autoload.git",
-                "reference": "2e3944571aa61b16336bea9254856f5ae4aea48c"
+                "reference": "ec0fb2b944fc267f2f3726dbc29744593452b0d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/2e3944571aa61b16336bea9254856f5ae4aea48c",
-                "reference": "2e3944571aa61b16336bea9254856f5ae4aea48c",
+                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/ec0fb2b944fc267f2f3726dbc29744593452b0d4",
+                "reference": "ec0fb2b944fc267f2f3726dbc29744593452b0d4",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0",
-                "fredemmott/hack-error-suppressor": "^1.0",
-                "hhvm": "^3.23"
+                "hhvm": "^3.28"
             },
             "replace": {
                 "facebook/hhvm-autoload": "1.*"
             },
             "require-dev": {
-                "91carriage/phpunit-hhi": "^5.5",
+                "91carriage/phpunit-hhi": "^5.7",
+                "facebook/fbexpect": "^1.1",
                 "phpunit/phpunit": "^5.5"
             },
             "bin": [
@@ -124,48 +123,55 @@
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2018-05-08T17:26:24+00:00"
+            "time": "2018-08-23T22:25:14+00:00"
         },
         {
             "name": "hhvm/hsl",
-            "version": "v1.4.0",
+            "version": "v3.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hsl.git",
-                "reference": "2d40281ec595b25a09bbe51d9216edbf1ad55a42"
+                "reference": "483c5e98e2a389f11e36a643d5aef06b024b6eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hsl/zipball/2d40281ec595b25a09bbe51d9216edbf1ad55a42",
-                "reference": "2d40281ec595b25a09bbe51d9216edbf1ad55a42",
+                "url": "https://api.github.com/repos/hhvm/hsl/zipball/483c5e98e2a389f11e36a643d5aef06b024b6eba",
+                "reference": "483c5e98e2a389f11e36a643d5aef06b024b6eba",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^3.23.2",
+                "hhvm": "^3.28.0",
                 "hhvm/hhvm-autoload": "^1.4"
             },
             "require-dev": {
-                "91carriage/phpunit-hhi": "^5.7",
-                "facebook/fbexpect": "^0.4",
-                "phpunit/phpunit": "^5.7"
+                "facebook/fbexpect": "^1.0.0",
+                "hhvm/hacktest": "^0.2"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
             "description": "The Hack Standard Library",
-            "time": "2018-03-09T21:53:48+00:00"
+            "time": "2018-08-27T18:09:57+00:00"
         },
         {
             "name": "hhvm/type-assert",
-            "version": "v3.2.2",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/type-assert.git",
-                "reference": "9bbe7cac2ff831142d74203479e72046cbc932f8"
+                "reference": "a6bdab8c7f9be9e3021ef08fc465d86d63c747b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/type-assert/zipball/9bbe7cac2ff831142d74203479e72046cbc932f8",
-                "reference": "9bbe7cac2ff831142d74203479e72046cbc932f8",
+                "url": "https://api.github.com/repos/hhvm/type-assert/zipball/a6bdab8c7f9be9e3021ef08fc465d86d63c747b0",
+                "reference": "a6bdab8c7f9be9e3021ef08fc465d86d63c747b0",
                 "shasum": ""
             },
             "require": {
@@ -176,9 +182,15 @@
             "require-dev": {
                 "91carriage/phpunit-hhi": "~5.1",
                 "facebook/fbexpect": "^0.4.0|^1.0.0",
+                "hhvm/hhast": "^3.27",
                 "phpunit/phpunit": "~5.1"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
@@ -188,7 +200,7 @@
                 "TypeAssert",
                 "hack"
             ],
-            "time": "2018-05-09T18:23:07+00:00"
+            "time": "2018-08-27T19:17:44+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
Imho we can drop the pre-release version 0.6 and move on to 3.28 (as this is experimental and I guess, we won't see an official final version until the next hhvm lts release).